### PR TITLE
JS-like unpacking (+ object property name shorthand)

### DIFF
--- a/moshmosh/__init__.py
+++ b/moshmosh/__init__.py
@@ -10,3 +10,4 @@ from .extensions import scoped_operators
 from .extensions import pipelines
 from .extensions import only_block
 from .extensions import quick_lambdas
+from .extensions import unpack_dot

--- a/moshmosh/__init__.py
+++ b/moshmosh/__init__.py
@@ -11,3 +11,4 @@ from .extensions import pipelines
 from .extensions import only_block
 from .extensions import quick_lambdas
 from .extensions import unpack_dot
+from .extensions import obj_shorthand

--- a/moshmosh/extensions/obj_shorthand.py
+++ b/moshmosh/extensions/obj_shorthand.py
@@ -1,0 +1,77 @@
+from moshmosh.extension import Extension
+from moshmosh.ast_compat import ast
+
+
+class ObjShorthand(Extension):
+    identifier = "obj-shorthand"
+
+    def rewrite_ast(self, node):
+        # return node
+        return ObjShorthandTransformer(self.activation).visit(node)
+
+
+# import ast
+# from ast import *
+
+
+class ObjShorthandTransformer(ast.NodeTransformer):
+    def __init__(self, activation):
+        self.activation = activation
+
+    def visit_Call(self, node):
+        if (
+            node.lineno in self.activation
+            and isinstance(node.func, ast.Name)
+            and node.func.id == 'obj'
+        ):
+            return self.rewrite_node(node)
+        else:
+            return node
+
+    def rewrite_node(self, node):
+        name_args, other_args = partition(node.args, lambda arg: isinstance(arg, ast.Name))
+        assert len(other_args) == 0
+        node.args = other_args
+        names = [arg.id for arg in name_args]
+        kwargs = [
+            ast.keyword(
+                arg=name,
+                value=ast.Name(id=name, ctx=ast.Load())
+            )
+            for name in names
+        ]
+        node.keywords.extend(kwargs)
+        return node
+
+
+def partition(lst, pred):
+    matches =    [x for x in lst if pred(x)]
+    nonmatches = [x for x in lst if not pred(x)]
+    return matches, nonmatches
+
+
+def main():
+    class MockActivation:
+        def __contains__(self, item):
+            return True
+
+
+    node = ast.parse(open('example.py').read())
+
+    # transformer = ObjShorthandTransformer(True)
+    # node = transformer.visit(node)
+    # # print('\n----------------------------\n')
+    # ast.fix_missing_locations(node)
+    # # exec(compile(node, filename="<ast>", mode="exec"))
+
+    # print(ast.dump(node, indent=4))
+    # print('\n----------------------------\n')
+    # print(ast.unparse(node))
+
+    ObjShorthandTransformer(MockActivation()).visit(node)
+    ast.fix_missing_locations(node)
+    print(ast.unparse(node))
+
+
+if __name__ == '__main__':
+    main()

--- a/moshmosh/extensions/unpack_dot.py
+++ b/moshmosh/extensions/unpack_dot.py
@@ -1,0 +1,107 @@
+from moshmosh.extension import Extension
+from moshmosh.ast_compat import ast
+
+import itertools
+
+
+class UnpackDot(Extension):
+    identifier = "unpack-dot"
+
+    def rewrite_ast(self, node):
+        # return node
+        return UnpackDotTransformer(self.activation).visit(node)
+
+
+# import itertools
+# import ast
+# from ast import *
+
+
+class UnpackDotTransformer(ast.NodeTransformer):
+    def __init__(self, activation):
+        self.activation = activation
+        self.ids = itertools.count()
+
+    def visit_Assign(self, node):
+        if (
+            node.lineno in self.activation
+            and isinstance(node.value, ast.Starred)
+        ):
+            return self.rewrite_node(node)
+        else:
+            return node
+
+    def rewrite_node(self, node):
+        # Replace e.g.
+        #   x, y = * right_side()
+        # With e.g.
+        #   _temp_0 = right_side()
+        #   x, y = (_temp_0.x, _temp_0.y)
+
+        # Or, for just one left-hand-side target, replace e.g.
+        #   x = * right_side()
+        # With e.g.
+        #   _temp_0 = right_side()
+        #   x = _temp_0.x
+
+        right_side = node.value.value
+        right_name = f'_temp_{next(self.ids)}'
+
+        assert len(node.targets) == 1
+        target = node.targets[0]
+        if isinstance(target, ast.Name):
+            left_names = [target.id]
+        else:
+            left_names = [name_node.id for name_node in target.elts]
+
+        if len(left_names) == 1:
+            left_name = left_names[0]
+            node.value = ast.Attribute(
+                value=ast.Name(id=right_name, ctx=ast.Load()),
+                attr=left_name,
+                ctx=ast.Load()
+            )
+        else:
+            node.value = ast.Tuple(
+                elts=[
+                    ast.Attribute(
+                        value=ast.Name(id=right_name, ctx=ast.Load()),
+                        attr=each,
+                        ctx=ast.Load()
+                    )
+                    for each in left_names
+                ],
+                ctx=ast.Load()
+            )
+
+        return [
+            ast.Assign(
+                targets=[
+                    ast.Name(id=right_name, ctx=ast.Store())
+                ],
+                value=right_side
+            ),
+            node,
+        ]
+
+
+def main():
+    node = ast.parse(open('example.py').read())
+
+    # transformer = UnpackDotTransformer(True)
+    # node = transformer.visit(node)
+    # # print('\n----------------------------\n')
+    # ast.fix_missing_locations(node)
+    # # exec(compile(node, filename="<ast>", mode="exec"))
+
+    # print(ast.dump(node, indent=4))
+    # print('\n----------------------------\n')
+    # print(ast.unparse(node))
+
+    UnpackDotTransformer(True).visit(node)
+    ast.fix_missing_locations(node)
+    print(ast.unparse(node))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Does not actually depend on 'only' branch -- just branched off of this for convenience

Examples: (expected output is `1 2 3` a few times)

```
# moshmosh?
# +unpack-dot
# +obj-shorthand

# n.b. `left =* right` is parsed as `left = *right` (starred expression `right`).
# I'm just pretending that it's an operator `=*`

from types import SimpleNamespace as obj

def foo():
    x = 1
    zee = 3
    return obj(x, y=2, z=zee)

def example1():
    x, y, z =* foo()
    print(x, y, z)
example1()

def example2():
    x =* foo()
    print(x, x*2, x*3)
example2()
```

- [x] Create 'unpack-dot' extension
- [x] Create 'obj-shorthand' extension
- [ ] Clean up
- [ ] Probably rename 'unpack-dot' to 'dot-unpacking' (consistency: others are nouns)